### PR TITLE
logscope: fix issue when using SILENT in Marlin

### DIFF
--- a/streamlog/source/include/streamlog/logscope.h
+++ b/streamlog/source/include/streamlog/logscope.h
@@ -65,7 +65,7 @@ namespace streamlog{
   protected: 
     logstream* _ls ;
     std::string _name ;
-    int _level;
+    long _level;
     logscope() {}
     
   };


### PR DESCRIPTION
`level` is `unsigned int` in most (all?) other places. SILENT is "UNSIGNED_INT_MAX", so the logic in this class with `int level = -1` doesn't work (any longer?). 

BEGINRELEASENOTES
- Logscope: fix for SILENT, which did not get properly restored because of integer overflow issues

ENDRELEASENOTES