### PR TITLE
revert "rm obsolete find macros ( LCIO, ROOT, CLHEP,...)"

### DIFF
--- a/cmakemodules/FindAIDA.cmake
+++ b/cmakemodules/FindAIDA.cmake
@@ -1,0 +1,46 @@
+################################################################
+# cmake module for finding AIDA
+#
+# requires AIDA_DIR set to a RAIDA implementation
+#
+# returns:
+#   AIDA_FOUND        : set to TRUE or FALSE
+#   AIDA_INCLUDE_DIRS : paths to AIDA includes
+#   AIDA_LIBRARY_DIRS : paths to AIDA libraries
+#   AIDA_LIBRARIES    : list of AIDA libraries
+#
+# @author Jan Engels, DESY
+################################################################
+
+SET( AIDA_FOUND FALSE )
+MARK_AS_ADVANCED( AIDA_FOUND )
+
+IF( AIDA_DIR )
+    SET( RAIDA_DIR "${AIDA_DIR}" CACHE PATH "Path to RAIDA" FORCE )
+ENDIF()
+
+FIND_PACKAGE( RAIDA QUIET )
+
+IF( RAIDA_FOUND )
+    
+    IF( NOT AIDA_FIND_QUIETLY )
+        FIND_PACKAGE( RAIDA )
+    ENDIF()
+
+    SET( AIDA_FOUND ${RAIDA_FOUND} )
+    SET( AIDA_INCLUDE_DIRS ${RAIDA_INCLUDE_DIRS} )
+    SET( AIDA_LIBRARY_DIRS ${RAIDA_LIBRARY_DIRS} )
+    SET( AIDA_LIBRARIES ${RAIDA_LIBRARIES} )
+    SET( AIDA_DEFINITIONS ${RAIDA_DEFINITIONS} )
+
+    MARK_AS_ADVANCED( AIDA_INCLUDE_DIRS AIDA_LIBRARY_DIRS AIDA_LIBRARIES AIDA_DEFINITIONS )
+
+ELSE()
+    IF( AIDA_FIND_REQUIRED )
+        MESSAGE( FATAL_ERROR "Check for AIDA -- failed" )
+    ENDIF()
+    IF( NOT AIDA_FIND_QUIETLY )
+        MESSAGE( STATUS "Check for AIDA -- not found" )
+    ENDIF()
+ENDIF()
+

--- a/cmakemodules/FindCERNLIB.cmake
+++ b/cmakemodules/FindCERNLIB.cmake
@@ -1,0 +1,42 @@
+#############################################################
+# cmake module for finding CERNLIB
+#
+# returns:
+#   CERNLIB_FOUND        : set to TRUE or FALSE
+#   CERNLIB_INCLUDE_DIRS : paths to cernlib includes
+#   CERNLIB_LIBRARY_DIRS : paths to cernlib libraries
+#   CERNLIB_LIBRARIES    : list of cernlib libraries
+#
+# @author Jan Engels, DESY
+#############################################################
+
+
+# ---------- includes ---------------------------------------------------------
+SET( CERNLIB_INCLUDE_DIRS CERNLIB_INCLUDE_DIRS-NOTFOUND )
+MARK_AS_ADVANCED( CERNLIB_INCLUDE_DIRS )
+
+FIND_PATH( CERNLIB_INCLUDE_DIRS NAMES cfortran/paw.h PATHS ${CERNLIB_DIR}/include NO_DEFAULT_PATH )
+IF( NOT CERNLIB_DIR )
+    FIND_PATH( CERNLIB_INCLUDE_DIRS NAMES cfortran/paw.h )
+ENDIF()
+
+IF( CERNLIB_INCLUDE_DIRS )
+    GET_FILENAME_COMPONENT( CERNLIB_ROOT ${CERNLIB_INCLUDE_DIRS} PATH )
+ENDIF()
+
+
+# ---------- libraries --------------------------------------------------------
+INCLUDE( MacroCheckPackageLibs )
+
+# only standard libraries should be passed as arguments to CHECK_PACKAGE_LIBS
+# additional components are set by cmake in variable PKG_FIND_COMPONENTS
+# first argument should be the package name
+CHECK_PACKAGE_LIBS( CERNLIB mathlib kernlib )
+
+
+
+# ---------- final checking ---------------------------------------------------
+INCLUDE( FindPackageHandleStandardArgs )
+# set CERNLIB_FOUND to TRUE if all listed variables are TRUE and not empty
+FIND_PACKAGE_HANDLE_STANDARD_ARGS( CERNLIB DEFAULT_MSG CERNLIB_INCLUDE_DIRS CERNLIB_LIBRARIES )
+

--- a/cmakemodules/FindCLHEP.cmake
+++ b/cmakemodules/FindCLHEP.cmake
@@ -1,0 +1,86 @@
+#############################################################
+# cmake module for finding CLHEP
+#
+# returns:
+#   CLHEP_FOUND        : set to TRUE or FALSE
+#   CLHEP_VERSION      : package version
+#   CLHEP_INCLUDE_DIRS : paths to clhep includes
+#   CLHEP_LIBRARY_DIRS : paths to clhep libraries
+#   CLHEP_LIBRARIES    : list of clhep libraries
+#
+# @author Jan Engels, DESY
+#############################################################
+
+
+# find clhep-config
+SET( CLHEP_CONFIG_EXECUTABLE CLHEP_CONFIG_EXECUTABLE-NOTFOUND )
+MARK_AS_ADVANCED( CLHEP_CONFIG_EXECUTABLE )
+FIND_PROGRAM( CLHEP_CONFIG_EXECUTABLE clhep-config PATHS ${CLHEP_DIR}/bin NO_DEFAULT_PATH )
+IF( NOT CLHEP_DIR )
+    FIND_PROGRAM( CLHEP_CONFIG_EXECUTABLE clhep-config )
+ENDIF()
+
+IF( CLHEP_CONFIG_EXECUTABLE )
+
+    # ==============================================
+    # ===          CLHEP_PREFIX                  ===
+    # ==============================================
+
+    EXECUTE_PROCESS( COMMAND "${CLHEP_CONFIG_EXECUTABLE}" --prefix
+        OUTPUT_VARIABLE CLHEP_ROOT
+        RESULT_VARIABLE _exit_code
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    IF( NOT _exit_code EQUAL 0 )
+        SET( CLHEP_ROOT )
+    ENDIF()
+
+
+    # ==============================================
+    # ===          CLHEP_VERSION                 ===
+    # ==============================================
+    INCLUDE( MacroCheckPackageVersion )
+
+    EXECUTE_PROCESS( COMMAND "${CLHEP_CONFIG_EXECUTABLE}" --version
+        OUTPUT_VARIABLE _output
+        RESULT_VARIABLE _exit_code
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    IF( _exit_code EQUAL 0 )
+        #SEPARATE_ARGUMENTS( CLHEP_VERSION UNIX_COMMAND "${_output}" ) # needs cmake >= 2.8
+        SET( CLHEP_VERSION ${_output} )
+        SEPARATE_ARGUMENTS( CLHEP_VERSION )
+        LIST( REMOVE_AT CLHEP_VERSION 0 ) # remove CLHEP string from output of 'clhep-config --version'
+        CHECK_PACKAGE_VERSION( CLHEP ${CLHEP_VERSION} )
+    ELSE()
+        SET( CLHEP_VERSION )
+    ENDIF()
+
+ENDIF( CLHEP_CONFIG_EXECUTABLE )
+
+
+# ---------- includes ---------------------------------------------------------
+SET( CLHEP_INCLUDE_DIRS CLHEP_INCLUDE_DIRS-NOTFOUND )
+MARK_AS_ADVANCED( CLHEP_INCLUDE_DIRS )
+
+FIND_PATH( CLHEP_INCLUDE_DIRS NAMES CLHEP/Vector/ThreeVector.h PATHS ${CLHEP_DIR}/include NO_DEFAULT_PATH )
+IF( NOT CLHEP_DIR )
+    FIND_PATH( CLHEP_INCLUDE_DIRS NAMES CLHEP/Vector/ThreeVector.h )
+ENDIF()
+
+
+# ---------- libraries --------------------------------------------------------
+INCLUDE( MacroCheckPackageLibs )
+
+# only standard libraries should be passed as arguments to CHECK_PACKAGE_LIBS
+# additional components are set by cmake in variable PKG_FIND_COMPONENTS
+# first argument should be the package name
+CHECK_PACKAGE_LIBS( CLHEP CLHEP )
+
+
+
+# ---------- final checking ---------------------------------------------------
+INCLUDE( FindPackageHandleStandardArgs )
+# set CLHEP_FOUND to TRUE if all listed variables are TRUE and not empty
+FIND_PACKAGE_HANDLE_STANDARD_ARGS( CLHEP DEFAULT_MSG CLHEP_INCLUDE_DIRS CLHEP_LIBRARIES PACKAGE_VERSION_COMPATIBLE )
+

--- a/cmakemodules/FindLCIO.cmake
+++ b/cmakemodules/FindLCIO.cmake
@@ -1,0 +1,65 @@
+#############################################################
+# cmake module for finding LCIO
+#
+# FIXME this module should be DEPRECATED
+#       LCIOConfig.cmake should be used instead
+#
+# requires:
+#   ZLIB
+#
+# returns:
+#   LCIO_FOUND        : set to TRUE or FALSE
+#   LCIO_INCLUDE_DIRS : paths to lcio includes
+#   LCIO_LIBRARY_DIRS : paths to lcio libraries
+#   LCIO_LIBRARIES    : list of lcio libraries
+#
+# @author Jan Engels, DESY
+#############################################################
+
+
+
+# ---------- includes ---------------------------------------------------------
+SET( LCIO_INCLUDE_DIRS LCIO_INCLUDE_DIRS-NOTFOUND )
+MARK_AS_ADVANCED( LCIO_INCLUDE_DIRS )
+
+FIND_PATH( LCIO_INCLUDE_DIRS
+    NAMES lcio.h
+    PATHS ${LCIO_DIR}/include
+    NO_DEFAULT_PATH
+)
+IF( NOT LCIO_DIR )
+    FIND_PATH( LCIO_INCLUDE_DIRS NAMES lcio.h )
+ENDIF()
+
+IF( LCIO_INCLUDE_DIRS )
+    GET_FILENAME_COMPONENT( LCIO_ROOT ${LCIO_INCLUDE_DIRS} PATH )
+ENDIF()
+
+
+# ---------- libraries --------------------------------------------------------
+INCLUDE( MacroCheckPackageLibs )
+
+# only standard libraries should be passed as arguments to CHECK_PACKAGE_LIBS
+# additional components are set by cmake in variable PKG_FIND_COMPONENTS
+# first argument should be the package name
+CHECK_PACKAGE_LIBS( LCIO lcio sio )
+
+
+
+# ------- zlib dependency -------------
+FIND_PACKAGE( ZLIB QUIET )
+IF( LCIO_DIR )
+    SET( LCIO_ROOT ${LCIO_DIR} ) # for MacroExportPackageDeps
+ENDIF()
+SET( LCIO_DEPENDS_LIBRARIES ${ZLIB_LIBRARIES} )
+INCLUDE( "MacroExportPackageDeps" )
+EXPORT_PACKAGE_DEPENDENCIES( LCIO ) # append ZLIB_LIBRARIES to LCIO_LIBRARIES unless FIND_PACKAGE_SKIP_DEPENDENCIES is set
+# -------------------------------------
+
+
+
+# ---------- final checking ---------------------------------------------------
+INCLUDE( FindPackageHandleStandardArgs )
+# set LCIO_FOUND to TRUE if all listed variables are TRUE and not empty
+FIND_PACKAGE_HANDLE_STANDARD_ARGS( LCIO DEFAULT_MSG LCIO_INCLUDE_DIRS LCIO_LIBRARIES ${LCIO_COMPONENT_VARIABLES} ZLIB_LIBRARIES )
+

--- a/cmakemodules/FindMokka.cmake
+++ b/cmakemodules/FindMokka.cmake
@@ -1,0 +1,94 @@
+########################################################################
+# cmake module for finding Mokka
+#
+# returns:
+#   Mokka_FOUND         : set to TRUE or FALSE
+#   Mokka_INCLUDE_DIRS  : paths to Mokka includes
+#   Mokka_LIBRARY_DIRS  : paths to Mokka libraries
+#   Mokka_LIBRARIES     : list of Mokka libraries (either set to
+#       libCGAPack - if found  - OR - Mokka libraries in $MOKKA/tmp )
+#   Mokka_CGA_FOUND     : set to TRUE or FALSE (checks for libCGAPack)
+#
+# @author Jan Engels, DESY
+########################################################################
+
+SET( CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS TRUE )
+
+SET( Mokka_CGA_FOUND FALSE )
+MARK_AS_ADVANCED( Mokka_CGA_FOUND )
+
+IF( NOT Mokka_FIND_QUIETLY )
+    MESSAGE( STATUS "Check for Mokka: ${Mokka_DIR}" )
+ENDIF()
+
+
+SET( Mokka_INCLUDE_DIRS Mokka_INCLUDE_DIRS-NOTFOUND )
+SET( Mokka_LIBRARIES Mokka_LIBRARIES-NOTFOUND )
+MARK_AS_ADVANCED ( Mokka_INCLUDE_DIRS Mokka_LIBRARIES )
+
+# include dirs
+IF( EXISTS "${Mokka_DIR}" )
+    
+    EXECUTE_PROCESS(
+        COMMAND find ${Mokka_DIR}/source -name include -type d # -printf "%p;" # not recognized on mac osx
+        OUTPUT_VARIABLE Mokka_INCLUDE_DIRS
+        RESULT_VARIABLE _exit_code
+    )
+        
+    IF( NOT _exit_code EQUAL 0 )
+        MESSAGE( STATUS "Check for Mokka includes -- failed (cmd: find Mokka_DIR/source -name include -type d" )
+        SET( Mokka_INCLUDE_DIRS Mokka_INCLUDE_DIRS-NOTFOUND )
+    ELSE()
+        #SEPARATE_ARGUMENTS( Mokka_INCLUDE_DIRS UNIX_COMMAND "${Mokka_INCLUDE_DIRS}" )
+        SEPARATE_ARGUMENTS( Mokka_INCLUDE_DIRS )
+    ENDIF()
+
+    IF( NOT DEFINED ENV{G4SYSTEM} )
+        SET( ENV{G4SYSTEM} "Linux-g++" )
+    ENDIF()
+
+    # libraries
+    FIND_LIBRARY( Mokka_LIBRARIES
+        NAMES CGAPack
+        PATHS "${Mokka_DIR}"  # $ENV{G4LIB}/$ENV{G4SYSTEM}
+        PATH_SUFFIXES lib lib/$ENV{G4SYSTEM}
+    )
+
+    IF( Mokka_LIBRARIES )
+        SET( Mokka_CGA_FOUND TRUE )
+        GET_FILENAME_COMPONENT( Mokka_LIBRARY_DIRS ${Mokka_LIBRARIES} PATH )
+    ELSE()
+        FILE( GLOB_RECURSE Mokka_LIBRARIES "${Mokka_DIR}/tmp/*.so" )
+        IF( NOT Mokka_LIBRARIES )
+            FILE( GLOB_RECURSE Mokka_LIBRARIES "${Mokka_DIR}/tmp/*.a" )
+        ENDIF()
+        IF( Mokka_LIBRARIES )
+            SET( Mokka_LIBRARY_DIRS "${Mokka_DIR}/tmp" ) # FIXME loop MOKKA_LIBS using GET_FILENAME_COMPONENT
+        ENDIF()
+    ENDIF()
+
+    IF( NOT Mokka_FIND_QUIETLY )
+        IF( Mokka_CGA_FOUND )
+            MESSAGE( STATUS "Check for Mokka libCGAPack -- ok" )
+        ELSE()
+            MESSAGE( STATUS "Check for Mokka libCGAPack -- failed -- did you compile Mokka with \"make MOKKA_PACK_LIBS=1\"?" )
+        ENDIF()
+    ENDIF()
+
+ENDIF()
+
+
+# debug
+#MESSAGE( STATUS "Mokka auto-detected include dirs: ${Mokka_INCLUDE_DIRS}" )
+#MESSAGE( STATUS "Mokka auto-detected libraries: ${Mokka_LIBRARIES}" )
+
+
+# ---------- final checking ---------------------------------------------------
+INCLUDE( FindPackageHandleStandardArgs )
+# set Mokka_FOUND to TRUE if all listed variables are TRUE and not empty
+FIND_PACKAGE_HANDLE_STANDARD_ARGS( Mokka DEFAULT_MSG Mokka_INCLUDE_DIRS Mokka_LIBRARIES )
+
+
+SET( Mokka_FOUND ${MOKKA_FOUND} )
+SET( MOKKA_CGA_FOUND ${Mokka_CGA_FOUND} )
+

--- a/cmakemodules/FindROOT.cmake
+++ b/cmakemodules/FindROOT.cmake
@@ -1,0 +1,321 @@
+###############################################################################
+# cmake module for finding ROOT
+#
+# requires:
+#   MacroCheckPackageLibs.cmake for checking package libraries
+#
+# Following cmake variables are returned by this module:
+#
+#   ROOT_FOUND              : set to TRUE if ROOT found
+#       If FIND_PACKAGE is called with REQUIRED and COMPONENTS arguments
+#       ROOT_FOUND is only set to TRUE if ALL components are found.
+#       If REQUIRED is NOT set components may or may not be available
+#
+#   ROOT_LIBRARIES          : list of ROOT libraries (NOT including COMPONENTS)
+#   ROOT_INCLUDE_DIRS       : list of paths to be used with INCLUDE_DIRECTORIES
+#   ROOT_LIBRARY_DIRS       : list of paths to be used with LINK_DIRECTORIES
+#   ROOT_COMPONENT_LIBRARIES    : list of ROOT component libraries
+#   ROOT_${COMPONENT}_FOUND     : set to TRUE or FALSE for each library
+#   ROOT_${COMPONENT}_LIBRARY   : path to individual libraries
+#   
+#
+#   Please note that by convention components should be entered exactly as
+#   the library names, i.e. the component name equivalent to the library
+#   $ROOTSYS/lib/libMathMore.so should be called MathMore and NOT:
+#       mathmore or Mathmore or MATHMORE
+#
+#   However to follow the usual cmake convention it is agreed that the
+#   ROOT_${COMPONENT}_FOUND and ROOT_${COMPONENT}_LIBRARY variables are ALL
+#   uppercase, i.e. the MathMore component returns: ROOT_MATHMORE_FOUND and
+#   ROOT_MATHMORE_LIBRARY NOT ROOT_MathMore_FOUND or ROOT_MathMore_LIBRARY
+#
+#
+# The additional ROOT components should be defined as follows:
+# FIND_PACKAGE( ROOT COMPONENTS MathMore Gdml Geom ...)
+#
+# If components are required use:
+# FIND_PACKAGE( ROOT REQUIRED COMPONENTS MathMore Gdml Geom ...)
+#
+# If only root is required and components are NOT required use:
+# FIND_PACKAGE( ROOT REQUIRED )
+# FIND_PACKAGE( ROOT COMPONENTS MathMore Gdml Geom ... QUIET )
+#   then you need to check for ROOT_MATHMORE_FOUND, ROOT_GDML_FOUND, etc.
+#
+# The variable ROOT_USE_COMPONENTS can also be used before calling
+# FIND_PACKAGE, i.e.:
+# SET( ROOT_USE_COMPONENTS MathMore Gdml Geom )
+# FIND_PACKAGE( ROOT REQUIRED ) # all ROOT_USE_COMPONENTS must also be found
+# FIND_PACKAGE( ROOT ) # check for ROOT_FOUND, ROOT_MATHMORE_FOUND, etc.
+#
+# @author Jan Engels, DESY
+###############################################################################
+
+
+
+# ==============================================
+# ===        ROOT_CONFIG_EXECUTABLE          ===
+# ==============================================
+
+SET( ROOT_CONFIG_EXECUTABLE ROOT_CONFIG_EXECUTABLE-NOTFOUND )
+MARK_AS_ADVANCED( ROOT_CONFIG_EXECUTABLE )
+# FIND_PROGRAM: Once one of the calls succeeds the result variable will be set and stored in the cache so that no call will search again. 
+FIND_PROGRAM( ROOT_CONFIG_EXECUTABLE root-config PATHS ${ROOT_DIR}/bin NO_DEFAULT_PATH )
+FIND_PROGRAM( ROOT_CONFIG_EXECUTABLE root-config PATHS $ENV{ROOTSYS}/bin NO_DEFAULT_PATH)
+FIND_PROGRAM( ROOT_CONFIG_EXECUTABLE root-config PATHS ENV PATH )
+FIND_PROGRAM( ROOT_CONFIG_EXECUTABLE root-config )
+
+
+
+IF( NOT ROOT_FIND_QUIETLY )
+    MESSAGE( STATUS "Check for ROOT_CONFIG_EXECUTABLE: ${ROOT_CONFIG_EXECUTABLE}" )
+ENDIF()
+
+
+IF( ROOT_CONFIG_EXECUTABLE )
+
+
+    # ==============================================
+    # ===          ROOT_VERSION                  ===
+    # ==============================================
+
+    INCLUDE( MacroCheckPackageVersion )
+    
+    EXECUTE_PROCESS( COMMAND "${ROOT_CONFIG_EXECUTABLE}" --version
+        OUTPUT_VARIABLE _version
+        RESULT_VARIABLE _exit_code
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    IF( _exit_code EQUAL 0 )
+
+        # set required variables for MacroCheckPackageVersion
+        STRING(REGEX REPLACE "^([0-9]+).*" "\\1" ROOT_VERSION_MAJOR "${_version}")
+        STRING(REGEX REPLACE "^[0-9]+.([0-9]+).*" "\\1" ROOT_VERSION_MINOR "${_version}")
+        STRING(REGEX REPLACE "^[0-9]+.[0-9]+.([0-9]+).*" "\\1" ROOT_VERSION_PATCH "${_version}")
+
+        SET( ROOT_VERSION "${ROOT_VERSION_MAJOR}.${ROOT_VERSION_MINOR}.${ROOT_VERSION_PATCH}" )
+    ENDIF()
+
+    CHECK_PACKAGE_VERSION( ROOT ${ROOT_VERSION} )
+
+
+
+    # ==============================================
+    # ===          ROOT_PREFIX                   ===
+    # ==============================================
+
+    # get root prefix from root-config output
+    EXECUTE_PROCESS( COMMAND "${ROOT_CONFIG_EXECUTABLE}" --prefix
+        OUTPUT_VARIABLE ROOT_PREFIX
+        RESULT_VARIABLE _exit_code
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    IF( NOT _exit_code EQUAL 0 )
+        # clear variable if root-config exits with error
+        # it might contain garbage
+        SET( ROOT_PREFIX )
+    ENDIF()
+
+    # PKG_ROOT variables are a cmake standard
+    # since this package is also called ROOT the variable name
+    # becomes ROOT_ROOT ...
+    SET( ROOT_ROOT ${ROOT_PREFIX} )
+
+
+
+    # ==============================================
+    # ===          ROOT_BIN_DIR                  ===
+    # ==============================================
+
+    # get bindir from root-config output
+    EXECUTE_PROCESS( COMMAND "${ROOT_CONFIG_EXECUTABLE}" --bindir
+        OUTPUT_VARIABLE ROOT_BIN_DIR
+        RESULT_VARIABLE _exit_code
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    IF( NOT _exit_code EQUAL 0 )
+        # clear variable if root-config exits with error
+        # it might contain garbage
+        SET( ROOT_BIN_DIR )
+    ENDIF()
+
+
+
+    # ==============================================
+    # ===          ROOT_EXECUTABLE               ===
+    # ==============================================
+
+
+    SET( ROOT_EXECUTABLE ROOT_EXECUTABLE-NOTFOUND )
+    MARK_AS_ADVANCED( ROOT_EXECUTABLE )
+    FIND_PROGRAM( ROOT_EXECUTABLE root PATHS ${ROOT_BIN_DIR} NO_DEFAULT_PATH )
+
+    IF( NOT ROOT_FIND_QUIETLY )
+        MESSAGE( STATUS "Check for ROOT_EXECUTABLE: ${ROOT_EXECUTABLE}" )
+    ENDIF()
+
+
+
+
+    # ==============================================
+    # ===          ROOT_CINT_EXECUTABLE          ===
+    # ==============================================
+
+
+    # find rootcint
+    SET( ROOT_CINT_EXECUTABLE ROOT_CINT_EXECUTABLE-NOTFOUND )
+    MARK_AS_ADVANCED( ROOT_CINT_EXECUTABLE )
+    FIND_PROGRAM( ROOT_CINT_EXECUTABLE rootcint PATHS ${ROOT_BIN_DIR} NO_DEFAULT_PATH )
+
+    IF( NOT ROOT_FIND_QUIETLY )
+        MESSAGE( STATUS "Check for ROOT_CINT_EXECUTABLE: ${ROOT_CINT_EXECUTABLE}" )
+    ENDIF()
+
+
+
+    # ==============================================
+    # ===          ROOT_INCLUDE_DIR              ===
+    # ==============================================
+
+    # get include dir from root-config output
+    EXECUTE_PROCESS( COMMAND "${ROOT_CONFIG_EXECUTABLE}" --incdir
+        OUTPUT_VARIABLE _inc_dir
+        RESULT_VARIABLE _exit_code
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    IF( NOT _exit_code EQUAL 0 )
+        # clear variable if root-config exits with error
+        # it might contain garbage
+        SET( _inc_dir )
+    ENDIF()
+
+
+    SET( ROOT_INCLUDE_DIRS ROOT_INCLUDE_DIRS-NOTFOUND )
+    MARK_AS_ADVANCED( ROOT_INCLUDE_DIRS )
+
+    FIND_PATH( ROOT_INCLUDE_DIRS
+        NAMES TH1.h
+        PATHS ${ROOT_DIR}/include ${_inc_dir}
+        NO_DEFAULT_PATH
+    )
+
+
+
+    # ==============================================
+    # ===            ROOT_LIBRARIES              ===
+    # ==============================================
+
+    # get library dir from root-config output
+    EXECUTE_PROCESS( COMMAND "${ROOT_CONFIG_EXECUTABLE}" --libdir
+        OUTPUT_VARIABLE ROOT_LIBRARY_DIR
+        RESULT_VARIABLE _exit_code
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    IF( NOT _exit_code EQUAL 0 )
+        # clear variable if root-config exits with error
+        # it might contain garbage
+        SET( ROOT_LIBRARY_DIR )
+    ENDIF()
+
+
+
+    # ========== standard root libraries =================
+
+    # standard root libraries (without components)
+    SET( _root_libnames )
+
+    # get standard root libraries from 'root-config --libs' output
+    EXECUTE_PROCESS( COMMAND "${ROOT_CONFIG_EXECUTABLE}" --noauxlibs --libs
+        OUTPUT_VARIABLE _aux
+        RESULT_VARIABLE _exit_code
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    IF( _exit_code EQUAL 0 )
+        
+        # create a list out of the output
+        SEPARATE_ARGUMENTS( _aux )
+
+        # remove first item -L compiler flag
+        LIST( REMOVE_AT _aux 0 )
+
+        FOREACH( _lib ${_aux} )
+
+            # extract libnames from -l compiler flags
+            STRING( REGEX REPLACE "^-.(.*)$" "\\1" _libname "${_lib}")
+
+            # fix for some root-config versions which export -lz even if using --noauxlibs
+            IF( NOT _libname STREQUAL "z" )
+
+                # append all library names into a list
+                LIST( APPEND _root_libnames ${_libname} )
+
+            ENDIF()
+
+        ENDFOREACH()
+
+    ENDIF()
+
+
+
+    # ========== additional root components =================
+
+    #LIST( APPEND ROOT_FIND_COMPONENTS Minuit2 ) # DEPRECATED !!!
+
+
+    # ---------- libraries --------------------------------------------------------
+    INCLUDE( MacroCheckPackageLibs )
+
+    SET( ROOT_LIB_SEARCH_PATH ${ROOT_LIBRARY_DIR} )
+
+    # only standard libraries should be passed as arguments to CHECK_PACKAGE_LIBS
+    # additional components are set by cmake in variable PKG_FIND_COMPONENTS
+    # first argument should be the package name
+    CHECK_PACKAGE_LIBS( ROOT ${_root_libnames} )
+
+
+
+
+    # ====== DL LIBRARY ==================================================
+    # workaround for cmake bug in 64 bit:
+    # see: http://public.kitware.com/mantis/view.php?id=10813
+    IF( CMAKE_SIZEOF_VOID_P EQUAL 8 )
+        FIND_LIBRARY( DL_LIB NAMES ${CMAKE_DL_LIBS} dl PATHS /usr/lib64 /lib64 NO_DEFAULT_PATH )
+    ENDIF( CMAKE_SIZEOF_VOID_P EQUAL 8 )
+
+    FIND_LIBRARY( DL_LIB NAMES ${CMAKE_DL_LIBS} dl )
+    MARK_AS_ADVANCED( DL_LIB )
+
+    IF( NOT ROOT_FIND_QUIETLY )
+        MESSAGE( STATUS "Check for libdl.so: ${DL_LIB}" )
+    ENDIF()
+
+ENDIF( ROOT_CONFIG_EXECUTABLE )
+
+# Threads library
+#FIND_PACKAGE( Threads REQUIRED)
+
+
+# ---------- final checking ---------------------------------------------------
+INCLUDE( FindPackageHandleStandardArgs )
+# set ROOT_FOUND to TRUE if all listed variables are TRUE and not empty
+# ROOT_COMPONENT_VARIABLES will be set if FIND_PACKAGE is called with REQUIRED argument
+FIND_PACKAGE_HANDLE_STANDARD_ARGS( ROOT DEFAULT_MSG ROOT_INCLUDE_DIRS ROOT_LIBRARIES ${ROOT_COMPONENT_VARIABLES} PACKAGE_VERSION_COMPATIBLE DL_LIB )
+
+IF( ROOT_FOUND )
+    LIST( APPEND ROOT_LIBRARIES ${DL_LIB} )
+    # FIXME DEPRECATED
+    SET( ROOT_DEFINITIONS "-DUSEROOT -DUSE_ROOT -DMARLIN_USE_ROOT" )
+    MARK_AS_ADVANCED( ROOT_DEFINITIONS )
+
+    # file including MACROS for generating root dictionary sources
+    GET_FILENAME_COMPONENT( _aux ${CMAKE_CURRENT_LIST_FILE} PATH )
+    SET( ROOT_DICT_MACROS_FILE ${_aux}/MacroRootDict.cmake )
+
+ENDIF( ROOT_FOUND )
+
+# ---------- cmake bug --------------------------------------------------------
+# ROOT_FIND_REQUIRED is not reset between FIND_PACKAGE calls, i.e. the following
+# code fails when geartgeo component not available: (fixed in cmake 2.8)
+# FIND_PACKAGE( ROOT REQUIRED )
+# FIND_PACKAGE( ROOT COMPONENTS geartgeo QUIET )
+SET( ROOT_FIND_REQUIRED )
+


### PR DESCRIPTION
Since packages still depend on this, this breaks the [build](https://gitlab.cern.ch/CLICdp/SoftwareConfigurations/iLCSoft/pipelines/278423)
BEGINRELEASENOTES
- revert from #7 "rm obsolete find macros ( LCIO, ROOT, CLHEP,...)"

ENDRELEASENOTES

