### PR TITLE
MacroRootDict: fix constant re-creation of dictionary

### DIFF
--- a/cmakemodules/MacroRootDict.cmake
+++ b/cmakemodules/MacroRootDict.cmake
@@ -165,7 +165,7 @@ MACRO( GEN_ROOT_DICT_SOURCE _dict_src_filename )
 
     STRING( REPLACE "/" "_" _dict_src_filename_nosc ${_dict_src_filename} )
     SET( _dict_src_file ${ROOT_DICT_OUTPUT_DIR}/${_dict_src_filename_nosc} )
-    STRING( REGEX REPLACE "^(.*)\\.(.*)$" "\\1.h" _dict_hdr_file "${_dict_src_file}" )
+    STRING( REGEX REPLACE "^(.*)\\.(.*)$" "\\1_rdict.pcm" _dict_hdr_file "${_dict_src_file}" )
     ADD_CUSTOM_COMMAND(
         OUTPUT  ${_dict_src_file} ${_dict_hdr_file}
         COMMAND mkdir -p ${ROOT_DICT_OUTPUT_DIR}


### PR DESCRIPTION
This should make developing LCFIPlus, KalTest, KalDet a bit less annoying because the dictionaries are not constantly created

BEGINRELEASENOTES
- MacroRootDict: fix constant re-creation of dictionary. ROOT_CINT is no longer creating *.h file but *_rdict.pcm, changing the expected output file will only recreate the dictionary when necessary

ENDRELEASENOTES