### PR TITLE
Fix a compilation warning

### DIFF
--- a/ilctest/include/ilctest/ILCTest.h
+++ b/ilctest/include/ilctest/ILCTest.h
@@ -2,6 +2,7 @@
 //#include <cstring>
 #include <sstream>
 #include <stdio.h>
+#include <cstring>
 #include <stdlib.h>
 
 class ILCTest{
@@ -46,6 +47,15 @@ public:
     }
 
 
+    bool isEqual (const char* v1, const char* v2)
+    {
+      return strcmp (v1, v2) == 0;
+    }
+    template <class V1, class V2 >
+    bool isEqual (const V1& v1, const V2& v2)
+    {
+      return (v1 == v2);
+    }
 
     // FIXME should this rather be called equals ? add another method not_equals ?
     template <class V1, class V2 >
@@ -54,7 +64,7 @@ public:
 
             std::stringstream sstr ;
 
-            if ( ! (v1 == v2)  ) {
+            if ( ! isEqual(v1, v2)  ) {
                 sstr << "  " << name<< " : [" << v1 << "] != [" << v2 << "]" ;
                 error( sstr.str() ) ;
             } 


### PR DESCRIPTION
When compiling iLCUtil v01-07 with gcc 13.1.1, we get a warning

```
inst/include/ilctest/ILCTest.h: In instantiation of ‘void ILCTest::operator()(const V1&, const V2&, std::string) [with V1 = char [6]; V2 = char [6]; std::string = std::__cxx11::basic_string<char>]’:
iLCUtil/example/hello_world.cc:25:16:   required from here
inst/include/ilctest/ILCTest.h:57:24: warning: comparison between two arrays [-Warray-compare]
   57 |             if ( ! (v1 == v2)  ) {
      |                    ~~~~^~~~~~
```

Fixed with this change; specialized the comparison for the c-string case.



BEGINRELEASENOTES
- Fix a compilation warning in ILCTest.h.
ENDRELEASENOTES