### PR TITLE
Write rpaths when installing

### DIFF
--- a/cmakemodules/ilcsoft_default_rpath_settings.cmake
+++ b/cmakemodules/ilcsoft_default_rpath_settings.cmake
@@ -15,6 +15,6 @@ if(APPLE)
     set(CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}")
   endif("${isSystemDir}" STREQUAL "-1")
 else()
-  set(CMAKE_SKIP_INSTALL_RPATH TRUE)           # skip the full RPATH for the install tree
+  set(CMAKE_SKIP_INSTALL_RPATH FALSE)           # skip the full RPATH for the install tree
 endif()
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Write rpaths when installing. Fixes an issue introduced in https://github.com/iLCSoft/iLCUtil/pull/32 where rpaths are not being written.

ENDRELEASENOTES

Before https://github.com/iLCSoft/iLCUtil/pull/32 and after for non-Apple platforms are not equivalent because before rpaths are being written and after they are not. I believe the default value of `CMAKE_SKIP_INSTALL_RPATH` is FALSE. With this change I can see rpaths are being written again.