### PR TITLE
Install the cmake files to lib/cmake/<PACKAGE_NAME>

### DIFF
--- a/cmake/ILCUTILConfig.cmake.in
+++ b/cmake/ILCUTILConfig.cmake.in
@@ -40,7 +40,7 @@ SET( ILCUTIL_REQUIRED_COMPONENT_VARIABLES )
 
 FOREACH( _component ${ILCUTIL_FIND_COMPONENTS} )
 
-    SET( _component_cfg_file "${ILCUTIL_ROOT}/${_component}Config.cmake" )
+    SET( _component_cfg_file "${ILCUTIL_ROOT}/lib/cmake/${_component}/${_component}Config.cmake" )
 
     IF( EXISTS "${_component_cfg_file}" )
         INCLUDE( "${_component_cfg_file}" )

--- a/cmakemodules/MacroGeneratePackageConfigFiles.cmake
+++ b/cmakemodules/MacroGeneratePackageConfigFiles.cmake
@@ -9,7 +9,7 @@ MACRO( GENERATE_PACKAGE_CONFIGURATION_FILES )
                 CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/cmake/${arg}.in"
                                 "${PROJECT_BINARY_DIR}/${arg}" @ONLY
                 )
-                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION . )
+                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/${PROJECT_NAME} )
                 #IF( EXISTS "${_current_dir}/MacroCheckPackageLibs.cmake" )
                 #    INSTALL( FILES "${_current_dir}/MacroCheckPackageLibs.cmake" DESTINATION cmake )
                 #ENDIF()
@@ -26,16 +26,16 @@ MACRO( GENERATE_PACKAGE_CONFIGURATION_FILES )
                 CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/cmake/${arg}.in"
                                 "${PROJECT_BINARY_DIR}/${arg}" @ONLY
                 )
-                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION . )
+                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/${PROJECT_NAME} )
                 #IF( EXISTS "${_current_dir}/MacroCheckPackageVersion.cmake" )
                 #    INSTALL( FILES "${_current_dir}/MacroCheckPackageVersion.cmake" DESTINATION cmake )
                 #ENDIF()
-            ENDIF( EXISTS "${PROJECT_SOURCE_DIR}/cmake/${arg}.in" )
+            ENDIF()
         ENDIF()
 
         IF( ${arg} MATCHES "LibDeps.cmake" )
             EXPORT_LIBRARY_DEPENDENCIES( "${arg}" )
-            INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION lib/cmake )
+            INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake )
         ENDIF()
 
     ENDFOREACH()


### PR DESCRIPTION
BEGINRELEASENOTES
- Install the cmake files to lib/cmake/<PACKAGE_NAME>

ENDRELEASENOTES

Currently how it works is that the `Config.cmake` files from packages that use iLCUtil are installed to the top directory. For LCGCMake views, the files in the top level directory do not belong in the view, and while building the stack works fine, building any package that needs to find these `Config.cmake` files won't work.

I propose to install them to `lib/cmake` (using `GNUInstallDirs` does not work since all the packages that are using the macro would need to have that included and that is not the case right now). This is how the installation folder ends up looking like:

``` 
/ilcutil/01.07.03/x86_64-el9-gcc14-opt/lib/cmake/ILCSOFT_CMAKE_MODULES:
total 16K
drwxr-xr-x. 2 sftnight sf 4.0K Feb  2 16:12 .
drwxr-xr-x. 6 sftnight sf 4.0K Feb  2 16:12 ..
-rw-r--r--. 1 sftnight sf 1.6K Feb  2 16:12 ILCSOFT_CMAKE_MODULESConfig.cmake
-rw-r--r--. 1 sftnight sf  581 Feb  2 16:12 ILCSOFT_CMAKE_MODULESConfigVersion.cmake
```

``` 
/ilcutil/01.07.03/x86_64-el9-gcc14-opt/lib/cmake/ILCTEST:
total 16K
drwxr-xr-x. 2 sftnight sf 4.0K Feb  2 16:12 .
drwxr-xr-x. 6 sftnight sf 4.0K Feb  2 16:12 ..
-rw-r--r--. 1 sftnight sf 1.7K Feb  2 16:12 ILCTESTConfig.cmake
-rw-r--r--. 1 sftnight sf  604 Feb  2 16:12 ILCTESTConfigVersion.cmake
```

``` 
/ilcutil/01.07.03/x86_64-el9-gcc14-opt/lib/cmake/ILCUTIL:
total 16K
drwxr-xr-x. 2 sftnight sf 4.0K Feb  2 16:12 .
drwxr-xr-x. 6 sftnight sf 4.0K Feb  2 16:12 ..
-rw-r--r--. 1 sftnight sf 2.1K Feb  2 16:12 ILCUTILConfig.cmake
-rw-r--r--. 1 sftnight sf  577 Feb  2 16:12 ILCUTILConfigVersion.cmake
```

``` 
/ilcutil/01.07.03/x86_64-el9-gcc14-opt/lib/cmake/streamlog:
total 16K
drwxr-xr-x. 2 sftnight sf 4.0K Feb  2 16:12 .
drwxr-xr-x. 6 sftnight sf 4.0K Feb  2 16:12 ..
-rw-r--r--. 1 sftnight sf 1.9K Feb  2 16:12 streamlogConfig.cmake
-rw-r--r--. 1 sftnight sf 3.2K Feb  2 16:12 streamlogConfigVersion.cmake
``` 

Packages that were already looking for the `Config.cmake` file in the top level folder will still find it because they also look in `lib/cmake/<PACKAGE_NAME>` (*with one exception below). In addition, leaving the `Deps.cmake` file under `lib/cmake` means no paths need to be changed in all those packages that hardcode it, see for example https://github.com/iLCSoft/CED/blob/8bcaae8d2c7f4800710d64a0613a1b4555aba6e1/cmake/CEDConfig.cmake.in#L57 or https://github.com/iLCSoft/KalDet/blob/a667b1799f185e3ed201eaec5d40ce9e685d95e5/cmake/KalDetConfig.cmake.in#L61.

*The exception is RAIDA. Many packages use `find_package(AIDA)`, which means they look for the `Config.cmake` files under `lib/cmake/AIDA` which wouldn't be there unless the installation is changed. In addition, `AIDAConfig.cmake` hardcodes finding `RAIDAConfig.cmake` to some location which would stop working (see https://github.com/iLCSoft/RAIDA/blob/master/cmake/AIDAConfig.cmake.in#L6), so a change would be needed.

*In summary*: This PR, together with one in RAIDA and a change in the installation instructions for RAIDA (for example in the spack recipe), make it possible to make stacks based on views on LCGCMake (probably any view-based stack) work.